### PR TITLE
Styleci updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: php
 php:
   - 7.2
   - nightly
+matrix:
+#Temporarily allow failures on PHP nightly while coveralls.io catches up.
+  allow_faailures:
+    - php: nightly
 
 install:
   # Making sure we're on the latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - nightly
 matrix:
 #Temporarily allow failures on PHP nightly while coveralls.io catches up.
-  allow_faailures:
+  allow_failures:
     - php: nightly
 
 install:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # laravel-mysqlite
 [![Build Status](https://travis-ci.org/spam-n-eggs/laravel-mysqlite.svg?branch=master)](https://travis-ci.org/spam-n-eggs/laravel-mysqlite)
 [![Coverage Status](https://coveralls.io/repos/github/spam-n-eggs/laravel-mysqlite/badge.svg?branch=master)](https://coveralls.io/github/spam-n-eggs/laravel-mysqlite?branch=master)
-[![StyleCI](https://github.styleci.io/repos/169732818/shield?branch=master)](https://github.styleci.io/repos/169732818)
+[![StyleCI](https://github.styleci.io/repos/167069269/shield?branch=master)](https://github.styleci.io/repos/167069269)
 [![Latest Stable Version](https://poser.pugx.org/spam-n-eggs/laravel-mysqlite/v/stable)](https://packagist.org/packages/spam-n-eggs/laravel-mysqlite)
 [![Total Downloads](https://poser.pugx.org/spam-n-eggs/laravel-mysqlite/downloads)](https://packagist.org/packages/spam-n-eggs/laravel-mysqlite)
 [![License](https://poser.pugx.org/spam-n-eggs/laravel-mysqlite/license)](https://packagist.org/packages/spam-n-eggs/laravel-mysqlite)


### PR DESCRIPTION
Description of changes
==
- Temporarily added a matrix to .travis-ci.yml in order to allow_failures for php nightly.
- Updated README.md with the correct URL for the StyleCI Badge.

Issues Addressed
==
- #18
- #19 

Testing Process
==
#19 
1. [Log into Travis CI](https://travis-ci.org/spam-n-eggs/laravel-mysqlite/builds/490645550), using a build that has a failed nightly build but a passed build on 7.x
1. Observe that the build has still passed.

#18 
1. Look at [README.md](README.md).
1. Click Through on the StyleCI badge.
1. **Observe** that referenced project is spam-n-eggs/laravel-mysql.