### PR TITLE
#23 Added PHP Version 7.3 to Travis requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.2
+  - 7.3
   - nightly
 matrix:
 #Temporarily allow failures on PHP nightly while coveralls.io catches up.


### PR DESCRIPTION
Description of changes
==
- Added 7.3 as one of the versions to build.

Issues Addressed
==
- #24 

Testing Process
==
#24 
1. [Log into Travis CI](https://travis-ci.org/spam-n-eggs/laravel-mysqlite/builds/492179311).
1. Observe that the build now has three builds still passed and that the 7.2 and 7.3 builds are successful.