### PR TITLE
Update composer suggests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,10 @@
         "phpunit/php-code-coverage": "^6.1@dev",
         "php-coveralls/php-coveralls": "2.1.x-dev"
     },
+    "suggest": {
+        "symfony/intl": "If you just need the en locale",
+        "ext-intl": "For locales other than en"
+    },
     "license": "MIT",
     "authors": [
         {

--- a/test/Mhorninger/MySQLite/StringMethodTest.php
+++ b/test/Mhorninger/MySQLite/StringMethodTest.php
@@ -51,7 +51,7 @@ class StringMethodTest extends \Mhorninger\TestCase
 
     public function testFormatWithMathProblem()
     {
-        $query = "SELECT FORMAT((3600 * 1.7 / 281), 1) as value";
+        $query = 'SELECT FORMAT((3600 * 1.7 / 281), 1) as value';
         $result = $this->conn->selectOne($query);
         $expected = '21.8';
         $this->assertEquals($expected, $result->value);

--- a/test/Mhorninger/MySQLite/StringMethodTest.php
+++ b/test/Mhorninger/MySQLite/StringMethodTest.php
@@ -49,6 +49,14 @@ class StringMethodTest extends \Mhorninger\TestCase
         $this->assertNull($result->value);
     }
 
+    public function testFormatWithMathProblem()
+    {
+        $query = "SELECT FORMAT((3600 * 1.7 / 281), 1) as value";
+        $result = $this->conn->selectOne($query);
+        $expected = '21.8';
+        $this->assertEquals($expected, $result->value);
+    }
+
     //endregion
 
     //region LPAD tests
@@ -74,6 +82,5 @@ class StringMethodTest extends \Mhorninger\TestCase
         $result = $this->conn->selectOne($query);
         $this->assertNull($result->value);
     }
-
     //endregion
 }

--- a/test/Mhorninger/MySQLite/StringMethodTest.php
+++ b/test/Mhorninger/MySQLite/StringMethodTest.php
@@ -82,5 +82,6 @@ class StringMethodTest extends \Mhorninger\TestCase
         $result = $this->conn->selectOne($query);
         $this->assertNull($result->value);
     }
+
     //endregion
 }


### PR DESCRIPTION
# Description of changes
* Added composer.json suggestions ext-intl or symfony/intl.
* Updated FORMAT method to default to 'en' locale for symfony/intl compatiblilty

# Issues Addressed
* #30 

# Testing Process
#30
1. In another project add spam-n-eggs: dev-update_composer_suggests as a requirement
2. Observe that it suggests both ext-intl and symfony/intl.