### PR TITLE
Upgraded to include all of the new Laravel Releases.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ['7.3', '7.4', '8.0']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     steps:
       - uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           extensions: sqlite3
 
       - name: Install Dependencies
@@ -87,7 +87,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           extensions: sqlite3
           coverage: xdebug
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5 || ^11.5 || ^12.5|| ^13.2",
         "squizlabs/php_codesniffer": "^4.0",
-        "phpstan/phpstan": "^2.2",
+        "phpstan/phpstan": "^1.12 || ^2.2",
         "codedungeon/phpunit-result-printer": "^0.32",
         "phpunit/php-code-coverage": "^9.2 || ^11.0 || ^12.5 || ^13.0 || ^14.2 "
     },

--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,19 @@
 {
     "name": "spam-n-eggs/laravel-mysqlite",
     "description": "MySQLite is a Laravel connector for SQLite that emulates MySQL functionality.  The currently ported functionalities can be viewed in README.md on the github site.",
-    "version": "1.4.0",
+    "version": "2.0.0",
     "type": "library",
     "require": {
         "vectorface/mysqlite": "^0.1.7 || ^0.2.0",
-        "illuminate/database": "^7.0 || ^8.0",
+        "illuminate/database": "^7.0 || ^8.0 || ^12.0 || ^13.0",
         "php": ">=7.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "^3.4",
-        "phpstan/phpstan": "^1.12",
-        "codedungeon/phpunit-result-printer": "dev-master",
-        "phpunit/php-code-coverage": "^9.2",
-        "php-coveralls/php-coveralls": "^2.4"
+        "phpunit/phpunit": "^9.5 || ^11.5 || ^12.5|| ^13.2",
+        "squizlabs/php_codesniffer": "^4.0",
+        "phpstan/phpstan": "^2.2",
+        "codedungeon/phpunit-result-printer": "^0.32",
+        "phpunit/php-code-coverage": "^9.2 || ^11.0 || ^12.5 || ^13.0 || ^14.2 "
     },
     "suggest": {
         "symfony/intl": "If you just need the en locale",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,22 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Comparison operation \"\\=\\=\" between Carbon\\\\CarbonImmutable\\|int and 1 results in an error\\.$#"
-			count: 1
-			path: src/Mhorninger/MySQLite/MySQLite.php
-
-		-
-			message: "#^Comparison operation \"\\>\\=\" between Carbon\\\\CarbonImmutable\\|int and 52 results in an error\\.$#"
-			count: 1
-			path: src/Mhorninger/MySQLite/MySQLite.php
-
-		-
 			message: "#^Method Mhorninger\\\\MySQLite\\\\MySQLite\\:\\:mysql_format\\(\\) should return string but return statement is missing\\.$#"
-			count: 1
-			path: src/Mhorninger/MySQLite/MySQLite.php
-
-		-
-			message: "#^PHPDoc tag @param has invalid value \\(mixed\\.\\.\\. number, decimals, culture\\.\\)\\: Unexpected token \"number\", expected variable at offset 115$#"
 			count: 1
 			path: src/Mhorninger/MySQLite/MySQLite.php
 

--- a/src/Mhorninger/MySQLite/MySQL/DateTimeExtended.php
+++ b/src/Mhorninger/MySQLite/MySQL/DateTimeExtended.php
@@ -112,7 +112,7 @@ trait DateTimeExtended
             $days = $dateTimeInterval->d;
             $hours = ($days * 24) + $dateTimeInterval->h;
             $hourFormatter = new \NumberFormatter(\Locale::DEFAULT_LOCALE, \NumberFormatter::PATTERN_DECIMAL, '00');
-            $hours = $hourFormatter->format($hours, \NumberFormatter::PATTERN_DECIMAL);
+            $hours = $hourFormatter->format($hours, \NumberFormatter::TYPE_DOUBLE);
 
             return $dateTimeInterval->format("%r$hours:%I:%S.%F");
         }

--- a/src/Mhorninger/MySQLite/MySQL/StringExtended.php
+++ b/src/Mhorninger/MySQLite/MySQL/StringExtended.php
@@ -7,9 +7,7 @@ use NumberFormatter;
 trait StringExtended
 {
     /**
-     * Format a number according to the nubmer of decimals provided and culture.
-     *
-     * @param mixed... number, decimals, culture.
+     * Format a number according to the number of decimals provided and culture.
      */
     // phpcs:disable
     public static function mysql_format()


### PR DESCRIPTION
Details
===
Upgraded package to support all new Laravel releases (12.x and 13.x), bumped version to 2.0.0, and updated dev dependencies and CI matrix to cover PHP 8.1–8.5. Fixed PHPStan baseline errors, corrected `NumberFormatter` usage in `DateTimeExtended` and `StringExtended`, and resolved PHPDoc/CI compatibility issues.

Steps to test changes
===
1. Run `composer update` to install the updated dependencies
2. Run `./vendor/bin/phpunit` to verify all tests pass
3. Run `./vendor/bin/phpstan analyse` to verify static analysis passes
4. Run `./vendor/bin/phpcs` to verify code style is correct
5. Confirm CI matrix now includes PHP 8.1, 8.2, 8.3, 8.4, and 8.5