### PR TITLE
Auto accept upgrades if the tests pass

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,62 @@
+name: Auto-merge Dependabot PRs
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: "${{ secrets.DEPENDABOT_PAT }}"
+          compat-lookup: true
+
+      - name: Skip if no compatibility score or below threshold
+        if: steps.metadata.outputs.compatibility-score < 80
+        run: |
+          SCORE="${{ steps.metadata.outputs.compatibility-score }}"
+          if [ "$SCORE" = "0" ]; then
+            echo "No compatibility score available — skipping auto-merge."
+          else
+            echo "Compatibility score $SCORE is below 80% threshold — skipping auto-merge."
+          fi
+          exit 1
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Bump composer.json version
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          BASE_VERSION=$(git show origin/${{ github.base_ref }}:composer.json | jq -r '.version')
+          PR_VERSION=$(jq -r '.version' composer.json)
+
+          if [ "$BASE_VERSION" = "$PR_VERSION" ]; then
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+            NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+
+            jq --arg ver "$NEW_VERSION" '.version = $ver' composer.json > composer.json.tmp
+            mv composer.json.tmp composer.json
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add composer.json
+            git commit -m "Bump package version to $NEW_VERSION"
+            git push
+          fi
+
+      - name: Auto-merge minor and patch updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_PAT }}


### PR DESCRIPTION
Details
===
Add a GitHub Actions workflow to automatically merge Dependabot PRs when the compatibility score is at or above 80%. The workflow also bumps the `composer.json` patch version prior to merge so the version bump lands with the dependency update.

For patch and minor updates meeting the score threshold, the PR branch gets a version bump commit (e.g. `1.4.0` → `1.4.1`) and auto-merge is enabled via squash. Major updates and updates with a compatibility score below 80% (or no score available) are left open for manual review.

Requires a Personal Access Token (`DEPENDABOT_PAT`) with `repo` scope stored as a repository secret to enable `compat-lookup`.

Steps to test changes
===
1. Push this branch and open a PR against `master`
2. Verify the new workflow file passes YAML validation
3. Check that Dependabot creates a PR for a composer or github-actions dependency update
4. Confirm the workflow fetches metadata, checks the compatibility score, bumps `composer.json` version, and enables auto-merge
