### PR TITLE
Test against Laravel 11 in CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         php-version: ['8.2', '8.3', '8.4']
+        illuminate-version: ['^11.0', '^12.0']
 
     steps:
       - uses: actions/checkout@v7
@@ -28,6 +29,27 @@ jobs:
           extensions: sqlite3
           coverage: xdebug
 
+      - name: Require specific illuminate version
+        run: composer require "illuminate/database:${{ matrix.illuminate-version }}" --no-update
+
+      - name: Install Dependencies
+        run: composer install --no-progress --prefer-dist
+
+      - name: Run Tests
+        run: ./vendor/bin/phpunit
+
+  static-analysis:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: sqlite3
+
       - name: Install Dependencies
         run: composer install --no-progress --prefer-dist
 
@@ -36,9 +58,6 @@ jobs:
 
       - name: Run Static Analysis
         run: ./vendor/bin/phpstan analyse --no-progress
-
-      - name: Run Tests
-        run: ./vendor/bin/phpunit
 
   security:
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "library",
     "require": {
         "vectorface/mysqlite": "^0.2.0",
-        "illuminate/database": "^12.0 || ^13.0",
+        "illuminate/database": "^11.0 || ^12.0 || ^13.0",
         "php": ">=8.2"
     },
     "require-dev": {


### PR DESCRIPTION
Details
===
Re-add `illuminate/database ^11.0` to the composer constraint (was accidentally dropped) and cross the CI test matrix across both PHP versions and illuminate versions.

- **`composer.json`**: `illuminate/database` constraint updated from `^12.0 || ^13.0` to `^11.0 || ^12.0 || ^13.0`
- **`.github/workflows/ci.yml`**:
  - `test` job: added `illuminate-version` matrix dimension (`^11.0`, `^12.0`) producing a full cross-product with PHP 8.2/8.3/8.4 (6 jobs). Each job runs `composer require --no-update` to pin the illuminate version before install.
  - New `static-analysis` job: runs `phpcs` + `phpstan` once (PHP 8.3) since these check package code quality, not cross-version compatibility.
  - Moved `phpcs`/`phpstan` out of the `test` job to avoid redundant runs across the matrix.

Steps to test changes
===
1. Push branch and observe CI runs 6 test jobs (3 PHP × 2 illuminate) and 1 static analysis job
2. Verify all matrix combinations pass
3. Confirm `phpcs` and `phpstan` run once in the `static-analysis` job

Issues Addressed
===
closes #127

Screenshots
===
N/A
